### PR TITLE
feat: Launchpad email integration with order status tracking (STS-2.6.3)

### DIFF
--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -31,7 +31,7 @@ interface OrderData {
   hotelSelection?: string;
 }
 
-const CSV_HEADER = 'Order ID,Date,Customer Name,Email,Phone,Company,Shipping Address,Freight Option,Freight Company,Freight Account,Freight Contact,Order Notes,Items,Total,Shop Type,PO Number,PO File,Hotel Selection';
+const CSV_HEADER = 'Order ID,Date,Customer Name,Email,Phone,Company,Shipping Address,Freight Option,Freight Company,Freight Account,Freight Contact,Order Notes,Items,Total,Shop Type,PO Number,PO File,Hotel Selection,Status,Tracking Number';
 
 function generateOrderId(): string {
   const timestamp = Date.now();
@@ -68,20 +68,24 @@ function ensureCSVHeader(ordersPath: string): void {
   const content = fs.readFileSync(ordersPath, 'utf-8');
   const firstLine = content.split('\n')[0] || '';
 
-  // If header already has the new columns, nothing to do
-  if (firstLine.includes('Shop Type')) {
+  // If header already has Status column, nothing to do
+  if (firstLine.includes('Status')) {
     return;
   }
 
-  // Migrate: replace old header with new, pad existing data rows with empty new columns
   const lines = content.split('\n');
   const migrated: string[] = [CSV_HEADER];
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i].trim();
     if (!line) continue;
-    // Append 4 empty columns for: Shop Type, PO Number, PO File, Hotel Selection
-    migrated.push(line + ',free,,,');
+    if (firstLine.includes('Shop Type')) {
+      // Has Shop Type columns but missing Status/Tracking Number — append 2 columns
+      migrated.push(line + ',Pending,');
+    } else {
+      // Old format — append Shop Type + PO + Hotel + Status + Tracking
+      migrated.push(line + ',free,,,,Pending,');
+    }
   }
 
   fs.writeFileSync(ordersPath, migrated.join('\n') + '\n', 'utf-8');
@@ -175,6 +179,8 @@ export async function POST(request: NextRequest) {
       escapeCSVField(poNumber),
       escapeCSVField(poFileRef),
       escapeCSVField(hotelSelection),
+      'Pending',
+      '',
     ].join(',');
 
     // Append to orders.csv
@@ -194,6 +200,17 @@ export async function POST(request: NextRequest) {
       })));
     } catch (e) {
       console.warn('Stock deduction failed (non-blocking):', e);
+    }
+
+    // Fire-and-forget: notify Launchpad for email notifications
+    const launchpadUrl = process.env.LAUNCHPAD_API_URL;
+    const shopSlug = process.env.SHOP_SLUG;
+    if (launchpadUrl && shopSlug) {
+      fetch(`${launchpadUrl}/api/shops/${shopSlug}/orders/notify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderData: { orderId, date: orderDate, ...orderData } }),
+      }).catch(err => console.warn('Launchpad notify failed (non-blocking):', err));
     }
 
     return NextResponse.json({

--- a/lib/design.ts
+++ b/lib/design.ts
@@ -46,6 +46,7 @@ export interface DesignData {
   style: Style;
   password: string;
   contactEmail: string;
+  adminEmail: string;
   logoPath: string | null;
   logoWhitePath: string | null;
   faviconPath: string | null;
@@ -335,6 +336,16 @@ export function getContactEmail(): string {
   }
 }
 
+export function getAdminEmail(): string {
+  try {
+    const adminEmailPath = path.join(DESIGN_PATH, 'Details', 'AdminEmail.txt');
+    const content = fs.readFileSync(adminEmailPath, 'utf-8').trim();
+    return content || '';
+  } catch {
+    return '';
+  }
+}
+
 export function getDesignData(): DesignData {
   return {
     colors: getColors(),
@@ -344,6 +355,7 @@ export function getDesignData(): DesignData {
     style: getStyle(),
     password: getPassword(),
     contactEmail: getContactEmail(),
+    adminEmail: getAdminEmail(),
     logoPath: getLogoPath('logo'),
     logoWhitePath: getLogoPath('logo-white'),
     faviconPath: getLogoPath('favicon'),

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -27,6 +27,7 @@
  * - STS-2.6.0 - Inventory tracking improvements, cart stock validation, order cancellation with 2-hour window, contact email, centered About Us
  * - STS-2.6.1 - Stock badges show actual box counts, populated inventory CSV with real stock levels
  * - STS-2.6.2 - Checkout inventory re-validation to prevent overselling, stock count on product page, negative stock allowed in CSV, description newline support
+ * - STS-2.6.3 - Launchpad email integration: order notify webhook, Status/Tracking columns in CSV, AdminEmail.txt support
  *
  * To increment version:
  * 1. Update VERSION constant below
@@ -35,14 +36,14 @@
  * 4. Commit with version number in commit message
  */
 
-export const VERSION = 'STS-2.6.2';
+export const VERSION = 'STS-2.6.3';
 
 export const VERSION_INFO = {
   name: 'Shop Template System',
   version: VERSION,
   codename: 'Guardian',
   releaseDate: '2026-03-04',
-  description: 'Checkout inventory re-validation to prevent overselling, stock count on product page, negative stock allowed in CSV, description newline support',
+  description: 'Launchpad email integration: order notify webhook, Status/Tracking columns in CSV, AdminEmail.txt support',
   attribution: 'Built with LR Paris Shuttle',
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shop-template-system",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Add Status and Tracking Number columns to orders CSV with backward-compatible migration
- Fire-and-forget POST to Launchpad notify endpoint after order creation for email notifications
- Add AdminEmail.txt support to design lib for admin notification emails
- New orders default to "Pending" status
- Reads LAUNCHPAD_API_URL and SHOP_SLUG env vars (set in docker-compose)
- Bump version to STS-2.6.3 / 2.0.5

https://claude.ai/code/session_01XccNGX7JYHvZAKiZeM5JAz